### PR TITLE
feat: publish to itch.io

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -107,17 +107,23 @@ runs:
       with:
         cmdline-tools-version: ${{ inputs.android_cmdline_tools_version }}
         log-accepted-android-sdk-licenses: false
-    - name: Build Android .apks
+    - name: Build Android debug .apk
       if: ${{ inputs.build_type == 'dev' }}
       shell: bash
       run: |
         pushd ./tools/love-android
-          ./gradlew assembleNormal${{ inputs.android_record }}Debug assembleNormal${{ inputs.android_record }}Release
+          ./gradlew assembleNormal${{ inputs.android_record }}Debug
         popd
-        mkdir -p ${{ inputs.output_folder }}/apk/{debug,release}
+        mkdir -p ${{ inputs.output_folder }}/apk/debug
         mv -v ./tools/love-android/app/build/outputs/apk/*/debug/app-normal-*-debug.apk ${{ inputs.output_folder }}/apk/debug/${{ inputs.product_name }}-${{ inputs.build_num }}-debug.apk
+    - name: Build Android release .apk
+      shell: bash
+      run: |
+        pushd ./tools/love-android
+          ./gradlew assembleNormal${{ inputs.android_record }}Release
+        popd
+        mkdir -p ${{ inputs.output_folder }}/apk/release
         mv -v ./tools/love-android/app/build/outputs/apk/*/release/app-normal-*-release-unsigned.apk ${{ inputs.output_folder }}/apk/release/${{ inputs.product_name }}-${{ inputs.build_num }}-release.apk
-        tree ${{ inputs.output_folder }}
     - name: Build Android .aab
       if: ${{ inputs.build_type == 'release' }}
       shell: bash

--- a/.github/actions/get-env/action.yml
+++ b/.github/actions/get-env/action.yml
@@ -14,11 +14,19 @@ runs:
           # Remove leading/trailing quotes if present
           cleaned_line=${line//\"/}
           echo "${cleaned_line}" >> $GITHUB_ENV
+          if [ "${cleaned_line}" == "AUDIO_MIC=true" ]; then
+            echo "ANDROID_RECORD=Record" >> $GITHUB_ENV
+          fi
+          if [ "${cleaned_line}" == "AUDIO_MIC=false" ]; then
+            echo "ANDROID_RECORD=NoRecord" >> $GITHUB_ENV
+          fi
+
+          # Convert PRODUCT_NAME to ITCH_GAME format only when processing PRODUCT_NAME
+          if [[ "${cleaned_line}" =~ ^PRODUCT_NAME= ]]; then
+            product_value=${cleaned_line#PRODUCT_NAME=}
+            echo "ITCH_GAME=$(echo ${product_value} | tr ' ' '-' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          fi
         done < ${{ inputs.env_file }}
-        case ${AUDIO_MIC} in
-          "true") echo "ANDROID_RECORD=Record" >> $GITHUB_ENV;;
-          *) echo "ANDROID_RECORD=NoRecord" >> $GITHUB_ENV;;
-        esac
 inputs:
   env_file:
     description: The environment variables file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
       previous_tag: ${{ steps.set_build.outputs.previous_tag }}
       release_id: ${{ steps.create_release.outputs.id || '' }}
       upload_url: ${{ steps.create_release.outputs.upload_url || '' }}
+      itch_game: ${{ env.ITCH_GAME }}
+      itch_user: ${{ env.ITCH_USER }}
       target_android: ${{ env.TARGET_ANDROID }}
       target_ios: ${{ env.TARGET_IOS }}
       target_linux_appimage: ${{ env.TARGET_LINUX_APPIMAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,6 +288,20 @@ jobs:
           asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-${{ env.BUILD_NUM }}.tar.gz
           asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.tar.gz
           asset_content_type: application/gzip
+      - name: Create unversioned AppImage for itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        run: |
+          cp -v ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-${{ env.BUILD_NUM }}.AppImage ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.AppImage
+      - name: Upload AppImage to itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_API_KEY }}
+          CHANNEL: linux_appimage
+          ITCH_GAME: ${{ needs.configure.outputs.itch_game }}
+          ITCH_USER: ${{ needs.configure.outputs.itch_user }}
+          PACKAGE: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.AppImage
+          VERSION: ${{ env.PRODUCT_VERSION }}
 
   build-windows:
     if: ${{ needs.configure.outputs.target_windows_zip == 'true' || needs.configure.outputs.target_windows_sfx == 'true' }}
@@ -381,6 +395,20 @@ jobs:
           asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-${{ env.BUILD_NUM }}.exe
           asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.exe
           asset_content_type: application/x-msdownload
+      - name: Create unversioned Windows SFX for itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        run: |
+          cp -v ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-${{ env.BUILD_NUM }}.exe ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.exe
+      - name: Upload Windows SFX to itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_windows_sfx == 'true' && needs.configure.outputs.itch_user != '' }}
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_API_KEY }}
+          CHANNEL: windows
+          ITCH_GAME: ${{ needs.configure.outputs.itch_game }}
+          ITCH_USER: ${{ needs.configure.outputs.itch_user }}
+          PACKAGE: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.exe
+          VERSION: ${{ env.PRODUCT_VERSION }}
 
   build-web:
     if: ${{ needs.configure.outputs.target_web == 'true' }}
@@ -438,6 +466,20 @@ jobs:
           asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-${{ env.BUILD_NUM }}_web.zip
           asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}_web.zip
           asset_content_type: application/zip
+      - name: Create unversioned Web release for itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        run: |
+          cp -v ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-${{ env.BUILD_NUM }}_web.zip ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}_web.zip
+      - name: Upload Web release to itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_API_KEY }}
+          CHANNEL: html
+          ITCH_GAME: ${{ needs.configure.outputs.itch_game }}
+          ITCH_USER: ${{ needs.configure.outputs.itch_user }}
+          PACKAGE: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}_web.zip
+          VERSION: ${{ env.PRODUCT_VERSION }}
 
   build-android:
     if: ${{ needs.configure.outputs.target_android == 'true' }}
@@ -535,6 +577,20 @@ jobs:
           asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}-release.aab
           asset_path: ${{ steps.sign-aab-release.outputs.signedReleaseFile }}
           asset_content_type: application/vnd.android.package-archive
+      - name: Create unversioned Android .apk for itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        run: |
+          cp -v ${{ steps.sign-apk-release.outputs.signedReleaseFile }} ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.apk
+      - name: Upload Android .apk to itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_API_KEY }}
+          CHANNEL: android
+          ITCH_GAME: ${{ needs.configure.outputs.itch_game }}
+          ITCH_USER: ${{ needs.configure.outputs.itch_user }}
+          PACKAGE: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.apk
+          VERSION: ${{ env.PRODUCT_VERSION }}
 
   build-macos:
     if: ${{ needs.configure.outputs.target_macos == 'true' }}
@@ -605,6 +661,20 @@ jobs:
           asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.dmg
           asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}-${{ env.BUILD_NUM }}.dmg
           asset_content_type: application/x-apple-diskimage
+      - name: Create unversioned macOS .dmg for itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        run: |
+          cp -v ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}-${{ env.BUILD_NUM }}.dmg ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}.dmg
+      - name: Upload macOS .dmg to itch.io
+        if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.itch_user != '' }}
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_API_KEY }}
+          CHANNEL: osx
+          ITCH_GAME: ${{ needs.configure.outputs.itch_game }}
+          ITCH_USER: ${{ needs.configure.outputs.itch_user }}
+          PACKAGE: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}.dmg
+          VERSION: ${{ env.PRODUCT_VERSION }}
 
   build-ios:
     if: ${{ needs.configure.outputs.target_ios == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -488,7 +488,6 @@ jobs:
           keyPassword: ${{ secrets.ANDROID_DEBUG_KEY_PASSWORD }}
           zipAlign: true
       - name: Sign Android release .apk
-        if: ${{ needs.configure.outputs.build_type == 'dev' }}
         id: sign-apk-release
         uses: kevin-david/zipalign-sign-android-release@v2
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LÖVE Template for Visual Studio Code
+# Bootstrap LÖVE Projects
 
-A pre-configured Visual Studio Code template for [LÖVE](https://love2d.org/) including GitHub Actions for automated builds.
+A pre-configured template for [LÖVE](https://love2d.org/) including GitHub Actions for automated builds.
 Inspired by and adapted from [LOVE VSCode Game Template](https://github.com/Keyslam/LOVE-VSCode-Game-Template) and [LÖVE Actions](https://github.com/love-actions).
 
 ## Features
@@ -30,7 +30,7 @@ Inspired by and adapted from [LOVE VSCode Game Template](https://github.com/Keys
 ## Setup
 
 - Use this template to [create a new repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) for your game, then clone that repository locally.
-- Open the `Workspace.code-workspace` file with Visual Studio Code.
+- Open the `Workspace.code-workspace` file with [Visual Studio Code](https://code.visualstudio.com/) or [VSCodium](https://vscodium.com/)
   - You will be prompted that there are recommended extensions.
     - Click 'Install'
   - If this does not happen, install:
@@ -41,12 +41,23 @@ Inspired by and adapted from [LOVE VSCode Game Template](https://github.com/Keys
     - [GitHub Local Actions](https://marketplace.visualstudio.com/items?itemName=SanjulaGanepola.github-local-actions) (*optional*)
     - [Shader languages support](https://marketplace.visualstudio.com/items?itemName=slevesque.shader) (*optional*)
 - Configure `game/product.env` and `game/conf.lua` with the settings specific to your game.
-  - **Make sure that `PRODUCT_UUID` is changed using `uuidgen`**.
+  - **Make sure that `PRODUCT_UUID` is changed using `uuidgen`** or the [UUID Generator](https://www.uuidgenerator.net/)
 - Replace `resources/icon.png` with your game's high-resolution icon.
+- Add the following secrets to your GitHub repository if you [build for Android](https://github.com/Oval-Tutu/bootstrap-love2d-project?tab=readme-ov-file#android):
+  - `ANDROID_DEBUG_SIGNINGKEY_BASE64`
+  - `ANDROID_DEBUG_ALIAS`
+  - `ANDROID_DEBUG_KEYSTORE_PASSWORD`
+  - `ANDROID_DEBUG_KEY_PASSWORD`
+  - `ANDROID_RELEASE_SIGNINGKEY_BASE64`
+  - `ANDROID_RELEASE_ALIAS`
+  - `ANDROID_RELEASE_KEYSTORE_PASSWORD`
+  - `ANDROID_RELEASE_KEY_PASSWORD`
+- Add the following secret to your GitHub repository if you want to publish to Itch.io:
+  - `BUTLER_API_KEY`
 
 ## Running
 
-- Press <kbd>Alt</kbd> + <kbd>L</kbd> or <kbd>Ctrl</kbd> + <kbd>F5</kbd> to **Run** the game.
+- Press <kbd>Ctrl</kbd> + <kbd>F5</kbd> to **Run** the game.
 - Press <kbd>F5</kbd> to **Debug** the game.
   - In debug mode you can use breakpoints and inspect variables.
   - This does have some performance impact though.
@@ -59,7 +70,60 @@ Doubles up as a poor man's backup system.
 
 - Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> to **Build** the game.
 
-# Releasing
+## Configuring
+
+The game and build settings are configured using `game/product.env`.
+The most important settings to change for your game:
+
+- `PRODUCT_NAME` - The name of your game
+- `PRODUCT_ID` - Unique identifier in reverse domain notation. **Can not contain spaces or hyphens**.
+- `PRODUCT_UUID` - Generate new UUID using `uuidgen` command or the [UUID Generator](https://www.uuidgenerator.net/)
+- `PRODUCT_DESC` - Short description of your game
+- `PRODUCT_COPYRIGHT` - Copyright notice
+- `PRODUCT_COMPANY` - Your company/organization name
+- `PRODUCT_WEBSITE` - Your game or company website
+
+### Build Targets
+
+You can disable build targets by setting them to `"false"` if you don't need builds for certain platforms.
+
+```shell
+# LÖVE version to target (only 11.5 is supported)
+LOVE_VERSION="11.5"
+
+# Enable/disable microphone access
+AUDIO_MIC="false"
+
+# Android screen orientation (landscape/portrait)
+ANDROID_ORIENTATION="landscape"
+
+# Itch.io username for publishing
+ITCH_USER="ovaltutu"
+
+# Build output directory
+OUTPUT_FOLDER="./builds"
+
+# Game metadata
+PRODUCT_NAME="Template"
+PRODUCT_ID="com.ovaltutu.template"
+PRODUCT_DESC="A template game made with LÖVE"
+PRODUCT_COPYRIGHT="Copyright (c) 2025 Oval Tutu"
+PRODUCT_COMPANY="Oval Tutu"
+PRODUCT_WEBSITE="https://oval-tutu.com"
+PRODUCT_UUID="3e64d17c-8797-4382-921f-cf488b22073f"
+
+# Enable/disable build targets
+TARGET_ANDROID="true"
+TARGET_IOS="true"
+TARGET_LINUX_APPIMAGE="true"
+TARGET_LINUX_TARBALL="true"
+TARGET_MACOS="true"
+TARGET_WEB="true"
+TARGET_WINDOWS_ZIP="true"
+TARGET_WINDOWS_SFX="true"
+```
+
+## Releasing
 
 Make a new release by creating a version number git tag **without the `v` prefix**.
 
@@ -75,6 +139,29 @@ git push origin 1.0.0
 ```
 
 - **GitHub Actions**: The GitHub workflow will automatically create a release and upload packages for all the supported platforms as an assets.
+
+### Publishing
+
+On a full release (a tagged version), the GitHub Actions workflow will automatically publish the game artifacts for the enabled platforms to the GitHub releases page.
+You can download the artifacts from the releases page and manually upload them to the appropriate stores.
+But you can also automate this process for the following platforms:
+
+#### Itch.io
+
+The GitHub Actions workflow will automatically publish the game artifacts for *enabled platforms* to Itch.io if `BUTLER_API_KEY` secret and `ITCH_USER` are set.
+Get your API key from [Itch.io account](https://itch.io/user/settings/api-keys).
+`ITCH_USER` from `game/product.env` will be used as the username, and `PRODUCT_NAME` from `game/product.env` (converted to lowercase with spaces replaced with hyphens `-`) will be used as the game name.
+
+For example this template project would attempt to publish to `ovaltutu/Template`.
+
+Not every artifact will be published to Itch.io, as some platforms are not supported, and some artifacts are unsuitable for distribution on Itch.io:
+
+- Android .apk files will be published to Itch.io if `TARGET_ANDROID` is enabled.
+- Linux AppImage files will be published to Itch.io if `TARGET_LINUX_APPIMAGE` is enabled.
+- macOS .dmg files will be published to Itch.io if `TARGET_MACOS` is enabled.
+- Windows win64 self-extracting .exe files will be published to Itch.io if `TARGET_WINDOWS_SFX` is enabled.
+- Web artifacts will be published to Itch.io if `TARGET_WEB` is enabled.
+- Itch.io does not support iOS artifacts.
 
 ## Structure
 ```
@@ -109,12 +196,12 @@ The `.vscode` folder contains project specific configuration.
 
 ## GitHub Actions
 
-The GitHub Actions workflow will automatically build and package the game for all the supported platforms.
+The GitHub Actions workflow will automatically build and package the game for all the supported platforms that are enabled in `game/product.env` and upload them as assets to the GitHub releases page.
 
 - Android
   - `.apk` debug and release builds for testing
   - `.aab` release build for the Play Store
-- iOS (*exporting to .ipa with notarization is not yet implemented*)
+- iOS (*notarization is not yet implemented*)
 - Linux
   - AppImage
   - Tarball
@@ -129,15 +216,40 @@ The GitHub Actions workflow will automatically build and package the game for al
 
 ### Local GitHub Action via act
 
-In order to use the GitHub Actions locally, you'll need to install [act](https://nektosact.com/) and Podman or Docker.
+In order to use the GitHub Actions locally, you'll need to install [act](https://nektosact.com/) and [Podman](https://podman.io/) or [Docker](https://www.docker.com/).
 
-This template includes `.actrc` which will source GitHub secrets and enable the artifact server.
+This template includes `.actrc` which will source local secrets and expose as GiutHub secrets to `act`.
+
+The `.actrc` file configures how `act` runs GitHub Actions locally:
+
+```plaintext
+# Load GitHub secrets from this file
+--secret-file=$HOME/.config/act/secrets
+
+# Store build artifacts in the ./builds directory
+--artifact-server-path=./builds
+
+# Force container architecture to linux/amd64
+--container-architecture=linux/amd64
+
+# Disable automatic pulling of container images
+--pull=false
+```
+
+Key configuration explained:
+
+- `--secret-file` - Path to file containing GitHub secrets (API keys, signing keys etc.)
+- `--artifact-server-path` - Local directory where build artifacts will be stored
+- `--container-architecture` - Forces x86_64 container architecture for compatibility
+- `--pull` - Prevents automatic downloading of container images on each run
+
+Create the secrets file at `~/.config/act/secrets` with your GitHub repository secrets before running act.
 
 #### macOS
 
-- Install Podman Desktop or Docker Desktop.
-- Install Xcode: `xcode-select --install`
-- Install additional tools: `brew install act create-dmg tree`
+- Install [Podman Desktop](https://podman-desktop.io/) or [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+- Install [Xcode](https://developer.apple.com/xcode/): `xcode-select --install`
+- Install additional tools via [Homebrew](https://brew.sh/): `brew install act create-dmg tree`
 
 ### Running the GitHub Actions locally
 
@@ -259,7 +371,7 @@ add_header Cross-Origin-Embedder-Policy "require-corp";
 add_header Set-Cookie "Path=/; HttpOnly; Secure";
 ```
 
-#### Itch.io
+#### Itch.io Web Player
 
 On [itch.io](https://itch.io/), the required HTTP headers are disabled by default, but they provide experimental support for enabling them.
 Learn how to [enable SharedArrayBuffer support on Itch.io](https://itch.io/t/2025776/experimental-sharedarraybuffer-support).

--- a/game/product.env
+++ b/game/product.env
@@ -1,6 +1,7 @@
 LOVE_VERSION="11.5"
 AUDIO_MIC="false"
 ANDROID_ORIENTATION="landscape"
+ITCH_USER="ovaltutu"
 OUTPUT_FOLDER="./builds"
 PRODUCT_NAME="Template"
 PRODUCT_ID="com.ovaltutu.template"


### PR DESCRIPTION
# Description

The GitHub Actions workflow will automatically publish the game artifacts for *enabled platforms* to Itch.io if `BUTLER_API_KEY` secret and `ITCH_USER` are set.
Get your API key from [Itch.io account](https://itch.io/user/settings/api-keys).
`ITCH_USER` from `game/product.env` will be used as the username, and `PRODUCT_NAME` from `game/product.env` (converted to lowercase with spaces replaced with hyphens `-`) will be used as the game name.

Not every artifact will be published to Itch.io, as some platforms are not supported, and some artifacts are unsuitable for distribution on Itch.io:

- Android .apk files will be published to Itch.io if `TARGET_ANDROID` is enabled.
- Linux AppImage files will be published to Itch.io if `TARGET_LINUX_APPIMAGE` is enabled.
- macOS .dmg files will be published to Itch.io if `TARGET_MACOS` is enabled.
- Windows win64 self-extracting .exe files will be published to Itch.io if `TARGET_WINDOWS_SFX` is enabled.
- Web artifacts will be published to Itch.io if `TARGET_WEB` is enabled.
- Itch.io does not support iOS artifacts.

- Closes #32

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation