### PR TITLE
fix: add PRODUCT_FILE to cater for game title with spaces in the name

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: Android version code
     required: false
     default: '1'
+  product_file:
+    description: The basename of the file to be generated
+    required: true
   product_id:
     description: Product ID - reverse domain name
     required: true
@@ -48,6 +51,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install tools
+      uses: ./.github/actions/install-tools
     - name: Checkout love-android ${{ inputs.android_love_version }}
       uses: actions/checkout@v4
       with:
@@ -123,7 +128,7 @@ runs:
         popd
         unzip -l ./tools/love-android/app/build/outputs/apk/*/debug/app-embed-*-debug.apk | grep -i '.so'
         mkdir -p ${{ inputs.output_folder }}/apk/debug
-        mv -v ./tools/love-android/app/build/outputs/apk/*/debug/app-embed-*-debug.apk ${{ inputs.output_folder }}/apk/debug/${{ inputs.product_name }}-debug.apk
+        mv -v ./tools/love-android/app/build/outputs/apk/*/debug/app-embed-*-debug.apk ${{ inputs.output_folder }}/apk/debug/${{ inputs.product_file }}-debug.apk
     - name: Build Android release .apk
       shell: bash
       run: |
@@ -132,7 +137,7 @@ runs:
         popd
         unzip -l ./tools/love-android/app/build/outputs/apk/*/release/app-embed-*-release-unsigned.apk | grep -i '.so'
         mkdir -p ${{ inputs.output_folder }}/apk/release
-        mv -v ./tools/love-android/app/build/outputs/apk/*/release/app-embed-*-release-unsigned.apk ${{ inputs.output_folder }}/apk/release/${{ inputs.product_name }}-release.apk
+        mv -v ./tools/love-android/app/build/outputs/apk/*/release/app-embed-*-release-unsigned.apk ${{ inputs.output_folder }}/apk/release/${{ inputs.product_file }}-release.apk
     - name: Build Android .aab
       if: ${{ inputs.build_type == 'release' }}
       shell: bash
@@ -142,4 +147,4 @@ runs:
         popd
         unzip -l ./tools/love-android/app/build/outputs/bundle/*/app-embed-*-release.aab | grep -i '.so'
         mkdir -p ${{ inputs.output_folder }}/aab/release
-        mv -v ./tools/love-android/app/build/outputs/bundle/*/app-embed-*-release.aab ${{ inputs.output_folder }}/aab/release/${{ inputs.product_name }}-release.aab
+        mv -v ./tools/love-android/app/build/outputs/bundle/*/app-embed-*-release.aab ${{ inputs.output_folder }}/aab/release/${{ inputs.product_file }}-release.aab

--- a/.github/actions/build-html/action.yml
+++ b/.github/actions/build-html/action.yml
@@ -1,0 +1,41 @@
+name: Build HTML Package
+description: Create an HTML build using love.js
+inputs:
+  output_folder:
+    description: The folder in which the generated package file will be placed
+    required: true
+  product_file:
+    description: The basename of the file to be generated
+    required: true
+  product_name:
+    description: The name of the game
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install tools
+      uses: ./.github/actions/install-tools
+    - name: Build LOVE package
+      uses: ./.github/actions/build-love
+      with:
+        output_folder: ${{ inputs.output_folder }}
+        product_file: ${{ inputs.product_file }}
+        product_name: ${{ inputs.product_name }}
+    - name: Build HTML package
+      shell: bash
+      run: |
+        #"${{ inputs.output_folder }}/${{ inputs.product_file }}.love" \
+        curl -fsSL --retry 5 --retry-delay 15 --connect-timeout 30 --max-time 300 https://github.com/2dengine/love.js/archive/refs/heads/main.zip -o ./tools/love.js.zip || exit 1
+        unzip -q ./tools/love.js.zip -d ./tools/
+        sed -i "s/<title>löve.js<\/title>/<title>${{ inputs.product_name }}<\/title>/" ./tools/love.js-main/index.html
+        sed -i '/<base href="\/play\/">$/d' ./tools/love.js-main/index.html
+        sed -i "s/player.js/player.js?g=game.love/" ./tools/love.js-main/index.html
+        convert ./resources/icon.png -define icon:auto-resize="256,128,96,64,48,32,24,16" ./tools/love.js-main/favicon.ico
+        mkdir -p "${{ inputs.output_folder }}/${{ inputs.product_file }}-html"
+        rsync -a --exclude='.htaccess' --exclude='*.git*' --exclude='*.md' --exclude='*.txt' \
+          ./tools/love.js-main/ \
+          ${{ inputs.output_folder }}/${{ inputs.product_file }}-html/
+        cp -v ${{ inputs.output_folder }}/${{ inputs.product_file }}.love ${{ inputs.output_folder }}/${{ inputs.product_file }}-html/game.love
+        7z a -tzip \
+          "${{ inputs.output_folder }}/${{ inputs.product_file }}-html.zip" \
+          "${{ inputs.output_folder }}/${{ inputs.product_file }}-html"/*

--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -17,6 +17,9 @@ inputs:
   product_id:
     description: The product ID of the game
     required: true
+  product_file:
+    description: The basename of the file to be generated
+    required: true
   product_name:
     description: The product name of the game
     required: true
@@ -29,6 +32,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install tools
+      uses: ./.github/actions/install-tools
+    - name: Build LOVE package
+      uses: ./.github/actions/build-love
+      with:
+        output_folder: ${{ inputs.output_folder}}
+        product_file: ${{ inputs.product_file }}
+        product_name: ${{ inputs.product_name }}
     - name: Checkout Love
       uses: actions/checkout@v4
       with:
@@ -49,11 +60,10 @@ runs:
       shell: bash
       run: |
         mv -v ./tools/love-apple-dependencies/iOS/libraries ./tools/love/platform/xcode/ios
-        cp -v ./${{ inputs.output_folder }}/${{ inputs.product_name }}.love ./tools/love/platform/xcode/game.love
+        cp -v ./${{ inputs.output_folder }}/${{ inputs.product_file }}.love ./tools/love/platform/xcode/game.love
     - name: Create iOS icons
       shell: bash
       run: |
-        tree ./tools/love
         rm -fv ./tools/love/platform/xcode/Images.xcassets/iOS\ AppIcon.appiconset/*.png
         sips -z 1024 1024 ./resources/icon.png --out ./tools/love/platform/xcode/Images.xcassets/iOS\ AppIcon.appiconset/icon-1024pt@1x.png
         sips -z 29 29 ./resources/icon.png --out ./tools/love/platform/xcode/Images.xcassets/iOS\ AppIcon.appiconset/icon-29pt@1x.png
@@ -74,7 +84,7 @@ runs:
         plutil -replace CFBundleName -string "${{ inputs.product_name }}" "$PLIST_FILE"
         plutil -replace CFBundleDisplayName -string "${{ inputs.product_name }}" "$PLIST_FILE"
         plutil -replace CFBundleIdentifier -string "${{ inputs.product_id }}" "$PLIST_FILE"
-        plutil -replace CFBundleExecutable -string "${{ inputs.product_name }}" "$PLIST_FILE"
+        plutil -replace CFBundleExecutable -string "${{ inputs.product_file }}" "$PLIST_FILE"
         plutil -replace CFBundleShortVersionString -string "${{ inputs.apple_version_code }}" "$PLIST_FILE"
         plutil -replace CFBundleVersion -string "${{ inputs.product_version }}" "$PLIST_FILE"
         plutil -replace ITSAppUsesNonExemptEncryption -bool false "$PLIST_FILE"
@@ -89,12 +99,15 @@ runs:
       run: |
         PROJECT_FILE="./tools/love/platform/xcode/love.xcodeproj/project.pbxproj"
         sed -i.bak 's/PRODUCT_BUNDLE_IDENTIFIER = org\.love2d\.love/PRODUCT_BUNDLE_IDENTIFIER = ${{ inputs.product_id }}/g' "$PROJECT_FILE"
-        sed -i.bak 's/PRODUCT_NAME = love/PRODUCT_NAME = ${{ inputs.product_name }}/g' "$PROJECT_FILE"
-        sed -i.bak 's/path = love\.app/path = ${{ inputs.product_name }}\.app/g' "$PROJECT_FILE"
-        sed -i.bak 's/productName = love/productName = ${{ inputs.product_name }}/g' "$PROJECT_FILE"
-        sed -i.bak 's/name = love/name = ${{ inputs.product_name }}/g' "$PROJECT_FILE"
+        sed -i.bak 's/PRODUCT_NAME = love/PRODUCT_NAME = ${{ inputs.product_file }}/g' "$PROJECT_FILE"
+        sed -i.bak 's/path = love\.app/path = ${{ inputs.product_file }}\.app/g' "$PROJECT_FILE"
+        sed -i.bak 's/productName = love/productName = ${{ inputs.product_file }}/g' "$PROJECT_FILE"
+        sed -i.bak 's/name = love/name = ${{ inputs.product_file }}/g' "$PROJECT_FILE"
         sed -i.bak 's/MARKETING_VERSION = ${{ inputs.love_version}}/MARKETING_VERSION = ${{ inputs.product_version }}/g' "$PROJECT_FILE"
-        cat "$PROJECT_FILE"
+        grep "${{ inputs.product_id }}" "$PROJECT_FILE" || true
+        grep "${{ inputs.product_file }}" "$PROJECT_FILE" || true
+        grep "${{ inputs.product_name }}" "$PROJECT_FILE" || true
+        grep "${{ inputs.product_version }}" "$PROJECT_FILE" || true
     - name: Update Resources to include game.love
       shell: bash
       run: |
@@ -139,7 +152,7 @@ runs:
             -scheme love-ios \
             -configuration Release \
             -destination 'generic/platform=iOS' \
-            -archivePath "${{ inputs.output_folder }}/${{ inputs.product_name }}.xcarchive" \
+            -archivePath "${{ inputs.output_folder }}/${{ inputs.product_file }}.xcarchive" \
             IPHONEOS_DEPLOYMENT_TARGET=12.0 \
             PRODUCT_BUNDLE_IDENTIFIER="${{ inputs.product_id }}" \
             CODE_SIGN_IDENTITY="" \
@@ -150,19 +163,20 @@ runs:
       shell: bash
       run: |
         # This is a poor emulation of the Xcode export process
-        cd ${{ inputs.output_folder}}
-        mkdir Payload
-        cp -r ${{ inputs.product_name }}.xcarchive/Products/Applications/${{ inputs.product_name }}.app Payload/
-        zip -r ${{ inputs.product_name }}.ipa Payload
-        rm -rf Payload
+        pushd ${{ inputs.output_folder}}
+          mkdir Payload
+          cp -r "${{ inputs.product_file }}.xcarchive/Products/Applications/${{ inputs.product_file }}.app" Payload/
+          zip -r "${{ inputs.product_file }}.ipa" Payload
+          rm -rf Payload
+        popd
     - name: Validate iOS app
       shell: bash
       run: |
-        md5sum ${{ inputs.output_folder}}/${{ inputs.product_name }}.love
-        md5sum ${{ inputs.output_folder}}//${{ inputs.product_name }}.xcarchive/Products/Applications/${{ inputs.product_name }}.app/game.love
-        plutil -lint ${{ inputs.output_folder}}/${{ inputs.product_name }}.xcarchive/Info.plist
-        plutil -p ${{ inputs.output_folder}}/${{ inputs.product_name }}.xcarchive/Info.plist
-        plutil -lint ${{ inputs.output_folder}}/${{ inputs.product_name }}.xcarchive/Products/Applications/${{ inputs.product_name }}.app/Info.plist
-        plutil -p ${{ inputs.output_folder}}/${{ inputs.product_name }}.xcarchive/Products/Applications/${{ inputs.product_name }}.app/Info.plist
+        md5sum "${{ inputs.output_folder}}/${{ inputs.product_file }}.love"
+        md5sum "${{ inputs.output_folder}}//${{ inputs.product_file }}.xcarchive/Products/Applications/${{ inputs.product_file }}.app/game.love"
+        plutil -lint "${{ inputs.output_folder}}/${{ inputs.product_file }}.xcarchive/Info.plist"
+        plutil -p "${{ inputs.output_folder}}/${{ inputs.product_file }}.xcarchive/Info.plist"
+        plutil -lint "${{ inputs.output_folder}}/${{ inputs.product_file }}.xcarchive/Products/Applications/${{ inputs.product_file }}.app/Info.plist"
+        plutil -p "${{ inputs.output_folder}}/${{ inputs.product_file }}.xcarchive/Products/Applications/${{ inputs.product_file }}.app/Info.plist"
         # Summary
         tree ${{ inputs.output_folder}}

--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -6,11 +6,14 @@ inputs:
   love_version:
     description: LÖVE version to use
     required: true
-  product_name:
-    description: Product name
-    required: true
   product_desc:
     description: Product description
+    required: true
+  product_file:
+    description: The basename of the file to be generated
+    required: true
+  product_name:
+    description: Product name
     required: true
   output_folder:
     description: Output folder path
@@ -18,6 +21,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install tools
+      uses: ./.github/actions/install-tools
+    - name: Build LOVE package
+      uses: ./.github/actions/build-love
+      with:
+        output_folder: ${{ inputs.output_folder }}
+        product_file: ${{ inputs.product_file }}
+        product_name: ${{ inputs.product_name }}
     - shell: bash
       run: |
         convert ./resources/icon.png -resize 256x256 "${{ inputs.output_folder }}/icon.png"
@@ -45,42 +56,42 @@ runs:
         rm -f ./tools/squashfs-root/love.desktop || true
 
         # Create .desktop file
-        cat > ./tools/squashfs-root/${{ inputs.product_name }}.desktop << EOF
+        cat > ./tools/squashfs-root/${{ inputs.product_file }}.desktop << EOF
         [Desktop Entry]
         Name=${{ inputs.product_name }}
         Comment=${{ inputs.product_desc }}
         Type=Application
         Keywords=love;game;
         Categories=Game;
-        Exec=${{ inputs.product_name }} %f
-        Icon=${{ inputs.product_name }}
+        Exec=${{ inputs.product_file }} %f
+        Icon=${{ inputs.product_file }}
         Terminal=false
         NoDisplay=false
         EOF
-        cp -v ./tools/squashfs-root/${{ inputs.product_name }}.desktop ./tools/squashfs-root/share/applications/${{ inputs.product_name }}.desktop
+        cp -v ./tools/squashfs-root/${{ inputs.product_file }}.desktop ./tools/squashfs-root/share/applications/${{ inputs.product_file }}.desktop
 
         echo "Assembling executable..."
-        sed -i 's|bin/love|bin/${{ inputs.product_name }}|g' ./tools/squashfs-root/AppRun
-        mv -v ./tools/squashfs-root/bin/love ./tools/squashfs-root/bin/${{ inputs.product_name }}
-        dd if=${{ inputs.output_folder }}/${{ inputs.product_name }}.love of=./tools/squashfs-root/bin/${{ inputs.product_name }} obs=1M oflag=append conv=notrunc
-        chmod +x ./tools/squashfs-root/bin/${{ inputs.product_name }}
+        sed -i 's|bin/love|bin/${{ inputs.product_file }}|g' ./tools/squashfs-root/AppRun
+        mv -v ./tools/squashfs-root/bin/love ./tools/squashfs-root/bin/${{ inputs.product_file }}
+        dd if=${{ inputs.output_folder }}/${{ inputs.product_file }}.love of=./tools/squashfs-root/bin/${{ inputs.product_file }} obs=1M oflag=append conv=notrunc
+        chmod +x ./tools/squashfs-root/bin/${{ inputs.product_file }}
 
         if [ -f "${{ inputs.output_folder }}/icon.png" ]; then
           echo "Copying icon..."
           ICON_PATH=$(basename -- "${{ inputs.output_folder }}/icon.png")
           mkdir -p ./tools/squashfs-root/share/icons/hicolor/256x256/apps
-          cp ${{ inputs.output_folder }}/icon.png "./tools/squashfs-root/share/icons/hicolor/256x256/apps/${{ inputs.product_name }}.${ICON_PATH##*.}"
-          cp ${{ inputs.output_folder }}/icon.png "./tools/squashfs-root/${{ inputs.product_name }}.${ICON_PATH##*.}"
+          cp ${{ inputs.output_folder }}/icon.png "./tools/squashfs-root/share/icons/hicolor/256x256/apps/${{ inputs.product_file }}.${ICON_PATH##*.}"
+          cp ${{ inputs.output_folder }}/icon.png "./tools/squashfs-root/${{ inputs.product_file }}.${ICON_PATH##*.}"
           cp ${{ inputs.output_folder }}/icon.png ./tools/squashfs-root/.DirIcon
         fi
 
         if [ "$ACT" == "true" ]; then
-          ./tools/appimagetool.AppImage --appimage-extract-and-run ./tools/squashfs-root ${{ inputs.output_folder }}/${{ inputs.product_name }}.AppImage
+          ./tools/appimagetool.AppImage --appimage-extract-and-run ./tools/squashfs-root ${{ inputs.output_folder }}/${{ inputs.product_file }}.AppImage
         else
-          ./tools/appimagetool.AppImage ./tools/squashfs-root ${{ inputs.output_folder }}/${{ inputs.product_name }}.AppImage
+          ./tools/appimagetool.AppImage ./tools/squashfs-root ${{ inputs.output_folder }}/${{ inputs.product_file }}.AppImage
         fi
-        chmod a+x ${{ inputs.output_folder }}/${{ inputs.product_name }}.AppImage
+        chmod a+x ${{ inputs.output_folder }}/${{ inputs.product_file }}.AppImage
 
         # Create tarball
-        mv -v ./tools/squashfs-root/AppRun ./tools/squashfs-root/${{ inputs.product_name }}
-        tar -czf ${{ inputs.output_folder }}/${{ inputs.product_name }}.tar.gz -C ./tools/squashfs-root .
+        mv -v ./tools/squashfs-root/AppRun ./tools/squashfs-root/${{ inputs.product_file }}
+        tar -czf ${{ inputs.output_folder }}/${{ inputs.product_file }}.tar.gz -C ./tools/squashfs-root .

--- a/.github/actions/build-love/action.yml
+++ b/.github/actions/build-love/action.yml
@@ -4,15 +4,20 @@ inputs:
   output_folder:
     description: The folder in which the generated .love file will be placed
     required: true
+  product_file:
+    description: The basename of the file to be generated
+    required: true
   product_name:
-    description: The name of the .love file
+    description: The name of the game
     required: true
 runs:
   using: composite
   steps:
+    - name: Install tools
+      uses: ./.github/actions/install-tools
     - name: Build LOVE package
       shell: bash
       run: |
         7z a -tzip -mx=6 -mpass=15 -mtc=off \
-        "${{ inputs.output_folder }}/${{ inputs.product_name }}.love" \
+        "${{ inputs.output_folder }}/${{ inputs.product_file }}.love" \
         ./game/* -xr!.gitkeep

--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -11,6 +11,9 @@ inputs:
   product_copyright:
     description: The product copyright of the game
     required: true
+  product_file:
+    description: The basename of the file to be generated
+    required: true
   product_id:
     description: The product ID of the macOS app
     required: true
@@ -28,17 +31,25 @@ runs:
   steps:
       # notorise .app
       # notarize .dmg
+    - name: Install tools
+      uses: ./.github/actions/install-tools
+    - name: Build LOVE package
+      uses: ./.github/actions/build-love
+      with:
+        output_folder: ${{ inputs.output_folder }}
+        product_file: ${{ inputs.product_file }}
+        product_name: ${{ inputs.product_name }}
     - name: Get LÖVE for macOS
       shell: bash
       run: |
         curl -fsSL --retry 5 --retry-delay 15 --connect-timeout 30 --max-time 300 https://github.com/love2d/love/releases/download/${{ inputs.love_version }}/love-${{ inputs.love_version }}-macos.zip -o ./tools/love-${{ inputs.love_version }}-macos.zip || exit 1
         7z x -o./tools/ ./tools/love-${{ inputs.love_version }}-macos.zip
-        mv -v ./tools/love.app ./tools/${{ inputs.product_name }}.app
-        rm -rfv ./tools/${{ inputs.product_name }}.app/Contents/Resources/*.icns
+        mv -v ./tools/love.app ./tools/${{ inputs.product_file }}.app
+        rm -rfv ./tools/${{ inputs.product_file }}.app/Contents/Resources/*.icns
     - name: Copy .love game
       shell: bash
-      run: cp -v ./${{ inputs.output_folder }}/*.love ./tools/${{ inputs.product_name }}.app/Contents/Resources/${{ inputs.product_name }}.love
-    - name: Create ${{ inputs.product_name}}.icns
+      run: cp -v ./${{ inputs.output_folder }}/*.love ./tools/${{ inputs.product_file }}.app/Contents/Resources/${{ inputs.product_file }}.love
+    - name: Create ${{ inputs.product_file}}.icns
       shell: bash
       run: |
         mkdir -p ./tools/icon.iconset
@@ -75,9 +86,9 @@ runs:
         fi
 
         if command -v iconutil >/dev/null 2>&1; then
-          iconutil -c icns ./tools/icon.iconset -o ./tools/${{ inputs.product_name }}.icns
+          iconutil -c icns ./tools/icon.iconset -o ./tools/${{ inputs.product_file }}.icns
         elif command -v png2icns >/dev/null 2>&1; then
-          png2icns ./tools/${{ inputs.product_name }}.icns \
+          png2icns ./tools/${{ inputs.product_file }}.icns \
             ./tools/icon.iconset/icon_16x16.png \
             ./tools/icon.iconset/icon_32x32.png \
             ./tools/icon.iconset/icon_128x128.png \
@@ -87,75 +98,41 @@ runs:
           echo "iconutil and png2icns not found"
           exit 1
         fi
-        cp -v ./tools/${{ inputs.product_name }}.icns ./tools/${{ inputs.product_name }}.app/Contents/Resources/
+        cp -v ./tools/${{ inputs.product_file }}.icns ./tools/${{ inputs.product_file }}.app/Contents/Resources/
     - name: Update Info.plist
       shell: bash
       run: |
         if command -v plutil >/dev/null 2>&1; then
           # Update Name, Identifier and Versions
           plutil -replace CFBundleIdentifier -string "${{ inputs.product_id }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
           plutil -replace CFBundleName -string "${{ inputs.product_name }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
           plutil -replace CFBundleShortVersionString -string "${{ inputs.product_version }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
           plutil -replace CFBundleVersion -string "${{ inputs.apple_version_code }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
 
           # Update icon
-          plutil -replace CFBundleIconFile -string "${{ inputs.product_name }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+          plutil -replace CFBundleIconFile -string "${{ inputs.product_file }}" \
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
           plutil -replace CFBundleIconName -string "${{ inputs.product_name }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
 
           # Update copyright
           plutil -replace NSHumanReadableCopyright -string "${{ inputs.product_copyright }}" \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
 
           # Remove CFBundleDocumentTypes, not required for a standalone game
           plutil -remove CFBundleDocumentTypes \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
 
           # Remove Uniform Type Identifiers. not required for a standalone game
           plutil -remove UTExportedTypeDeclarations \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+            ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
         else
-          # Update Name, Identifier and Versions
-          xmlstarlet ed -L \
-            -u '/plist/dict/string[preceding-sibling::key[1][text()="CFBundleIdentifier"]]' \
-            -v '${{ inputs.product_id }}' \
-            -u '/plist/dict/string[preceding-sibling::key[1][text()="CFBundleName"]]' \
-            -v '${{ inputs.product_name }}' \
-            -u '/plist/dict/string[preceding-sibling::key[1][text()="CFBundleShortVersionString"]]' \
-            -v '${{ inputs.product_version }}' \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
-          xmlstarlet ed -L -s '/plist/dict' -t elem -n 'key' -v 'CFBundleVersion' \
-            -s '/plist/dict' -t elem -n 'string' -v '${{ inputs.apple_version_code }}' \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
-
-          # Update icon
-          xmlstarlet ed -L \
-            -u '/plist/dict/string[preceding-sibling::key[1][text()="CFBundleIconFile"]]' \
-            -v '${{ inputs.product_name }}' \
-            -u '/plist/dict/string[preceding-sibling::key[1][text()="CFBundleIconName"]]' \
-            -v '${{ inputs.product_name }}' \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
-
-          # Update copyright
-          xmlstarlet ed -L \
-            -u '/plist/dict/string[preceding-sibling::key[1][text()="NSHumanReadableCopyright"]]' \
-            -v '${{ inputs.product_copyright }}' \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
-
-          # Remove CFBundleDocumentTypes, not required for a standalone game
-          xmlstarlet ed -L \
-            -d '/plist/dict/key[text()="CFBundleDocumentTypes"]|/plist/dict/array[preceding-sibling::key[1][text()="CFBundleDocumentTypes"]]' \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
-
-          # Remove Uniform Type Identifiers. not required for a standalone game
-          xmlstarlet ed -L \
-            -d '/plist/dict/key[text()="UTExportedTypeDeclarations"]|/plist/dict/array[preceding-sibling::key[1][text()="UTExportedTypeDeclarations"]]' \
-            ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+          echo "plutil not found"
+          exit 1
         fi
     - name: Validate Info.plist
       shell: bash
@@ -174,23 +151,18 @@ runs:
           fi
           ' sh {} \;
         else
-          curl -fsSL --retry 5 --retry-delay 15 --connect-timeout 30 --max-time 300 \
-            https://www.apple.com/DTDs/PropertyList-1.0.dtd \
-            -o ./tools/${{ inputs.product_name }}.app/Contents/PropertyList-1.0.dtd || exit 1
-          sed 's|http://www.apple.com/DTDs/PropertyList-1.0.dtd|PropertyList-1.0.dtd|g' ./tools/${{ inputs.product_name }}.app/Contents/Info.plist > ./tools/${{ inputs.product_name }}.app/Contents/Check.plist
-          xmlstarlet val -e -d ./tools/${{ inputs.product_name }}.app/Contents/PropertyList-1.0.dtd --net ./tools/${{ inputs.product_name }}.app/Contents/Check.plist
-          rm ./tools/${{ inputs.product_name }}.app/Contents/Check.plist
-          rm ./tools/${{ inputs.product_name }}.app/Contents/PropertyList-1.0.dtd
+          echo "plutil not found"
+          exit 1
         fi
-        tree ./tools/${{ inputs.product_name }}.app
-        cat ./tools/${{ inputs.product_name }}.app/Contents/Info.plist
+        tree ./tools/${{ inputs.product_file }}.app
+        cat ./tools/${{ inputs.product_file }}.app/Contents/Info.plist
     - name: Create macOS .zip of .app
       shell: bash
       run: |
         if command -v ditto >/dev/null 2>&1; then
-          ditto -c -k --keepParent ./tools/${{ inputs.product_name }}.app ${{ inputs.output_folder }}/${{ inputs.product_name }}.app.zip
+          ditto -c -k --keepParent ./tools/${{ inputs.product_file }}.app ${{ inputs.output_folder }}/${{ inputs.product_file }}.app.zip
         else
-          zip -ry --symlinks ${{ inputs.output_folder }}/${{ inputs.product_name }}.app.zip ./tools/${{ inputs.product_name }}.app
+          zip -ry --symlinks ${{ inputs.output_folder }}/${{ inputs.product_file }}.app.zip ./tools/${{ inputs.product_file }}.app
         fi
         tree ${{ inputs.output_folder }}
     - name: Create macOS .dmg of .app
@@ -198,16 +170,16 @@ runs:
       shell: bash
       run: |
         #--background "./resources/background.png" \
-        #--volicon ./tools/${{ inputs.product_name }}.icns \
+        #--volicon ./tools/${{ inputs.product_file }}.icns \
         create-dmg \
-          --volname "${{ inputs.product_name }}" \
+          --volname "${{ inputs.product_file }}" \
           --window-pos 200 120 \
           --window-size 800 400 \
           --icon-size 100 \
-          --icon "${{ inputs.product_name }}.app" 200 190 \
-          --hide-extension "${{ inputs.product_name }}.app" \
+          --icon "${{ inputs.product_file }}.app" 200 190 \
+          --hide-extension "${{ inputs.product_file }}.app" \
           --app-drop-link 600 185 \
           --no-internet-enable \
           --skip-jenkins \
-          ${{ inputs.output_folder }}/${{ inputs.product_name }}.dmg \
-          ./tools/${{ inputs.product_name }}.app/
+          ${{ inputs.output_folder }}/${{ inputs.product_file }}.dmg \
+          ./tools/${{ inputs.product_file }}.app/

--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -21,6 +21,9 @@ inputs:
   product_desc:
     description: Product description
     required: true
+  product_file:
+    description: The basename of the file to be generated
+    required: true
   product_name:
     description: Product name
     required: true
@@ -50,6 +53,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install tools
+      uses: ./.github/actions/install-tools
+    - name: Build LOVE package
+      uses: ./.github/actions/build-love
+      with:
+        output_folder: ${{ inputs.output_folder }}
+        product_file: ${{ inputs.product_file }}
+        product_name: ${{ inputs.product_name }}
     - name: Install WineHQ
       shell: bash
       run: |
@@ -99,7 +110,7 @@ runs:
             --set-version-string FileDescription "${{ inputs.product_desc }}" \
             --set-version-string InternalName "${{ inputs.product_name }}" \
             --set-version-string LegalCopyright "${{ inputs.product_copyright }}" \
-            --set-version-string OriginalFilename "${{ inputs.product_name }}.exe" \
+            --set-version-string OriginalFilename "${{ inputs.product_file }}.exe" \
             --set-version-string PrivateBuild "${{ inputs.build_num }}" \
             --set-file-version "${{ inputs.build_num }}" \
             --set-product-version "${{ inputs.product_version }}" \
@@ -111,15 +122,15 @@ runs:
         for ARCH in win64; do
           mkdir -p ./tools/build/$ARCH/
           cp ./tools/love-$ARCH/* ./tools/build/$ARCH/
-          mv -v ./tools/build/$ARCH/love.exe ./tools/build/$ARCH/${{ inputs.product_name }}.exe
-          dd if=${{ inputs.output_folder }}/${{ inputs.product_name }}.love of=./tools/build/$ARCH/${{ inputs.product_name }}.exe obs=1M oflag=append conv=notrunc
+          mv -v ./tools/build/$ARCH/love.exe ./tools/build/$ARCH/${{ inputs.product_file }}.exe
+          dd if=${{ inputs.output_folder }}/${{ inputs.product_file }}.love of=./tools/build/$ARCH/${{ inputs.product_file }}.exe obs=1M oflag=append conv=notrunc
         done
     - name: Create Windows .zip files
       if: ${{ inputs.build_type == 'release' && inputs.target_windows_zip == 'true' }}
       shell: bash
       run: |
         for ARCH in win64; do
-          7z a -tzip -mx=9 -mfb=273 -mpass=15 -mtc=off ${{ inputs.output_folder }}/${{ inputs.product_name }}.zip ./tools/build/$ARCH/*
+          7z a -tzip -mx=9 -mfb=273 -mpass=15 -mtc=off ${{ inputs.output_folder }}/${{ inputs.product_file }}.zip ./tools/build/$ARCH/*
         done
     # https://gist.github.com/drewchapin/246de6d0c404a79ee66a5ead35b480bc
     # https://github.com/AnonymerNiklasistanonym/NsiWindowsInstallerExamples/blob/main/example_02_license_uninstaller_components/windows_installer.nsi
@@ -145,6 +156,7 @@ runs:
         ;-------------------------------------------------------------------------------
         ; Constants
         !define PRODUCT_NAME "${{ inputs.product_name }}"
+        !define PRODUCT_FILE "${{ inputs.product_file }}"
         !define PRODUCT_COMPANY "${{ inputs.product_company }}"
         !define PRODUCT_COPYRIGHT "${{ inputs.product_copyright }}"
         !define PRODUCT_DESCRIPTION "${{ inputs.product_desc }}"
@@ -157,7 +169,7 @@ runs:
         ;-------------------------------------------------------------------------------
         ; Attributes
         Name "${PRODUCT_NAME}"
-        OutFile "${{ inputs.output_folder }}/${PRODUCT_NAME}-installer.exe"
+        OutFile "${{ inputs.output_folder }}/${PRODUCT_FILE}-installer.exe"
         InstallDir "${PRODUCT_DIR}"
         InstallDirRegKey HKCU "Software\${PRODUCT_COMPANY}\${PRODUCT_NAME}" ""
         RequestExecutionLevel user ; user|highest|admin
@@ -191,7 +203,7 @@ runs:
         !insertmacro MUI_PAGE_FINISH
         LangString DESC_Section1 ${LANG_ENGLISH} "Runtime and game data for ${PRODUCT_NAME} v${PRODUCT_VERSION} (${BUILD_VERSION})"
         !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-          !insertmacro MUI_DESCRIPTION_TEXT ${Section1} $(DESC_Section1)
+          !insertmacro MUI_DESCRIPTION_TEXT Section1 DESC_Section1
         !insertmacro MUI_FUNCTION_DESCRIPTION_END
         ;-------------------------------------------------------------------------------
         ; Uninstaller Pages
@@ -209,10 +221,10 @@ runs:
           SetOutPath "$INSTDIR"
           File /r "./tools/build/win64/*"
           ; Add icon to the uninstaller executable
-          CreateShortcut "$SMPROGRAMS\${PRODUCT_NAME}.lnk" "$INSTDIR\${PRODUCT_NAME}.exe"
+          CreateShortcut "$SMPROGRAMS\${PRODUCT_NAME}.lnk" "$INSTDIR\${PRODUCT_FILE}.exe"
           ;Create an uninstaller that will also be recognized by Windows:
           WriteRegStr   HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_UUID}" "DisplayName"          "${PRODUCT_NAME}"
-          WriteRegStr   HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_UUID}" "DisplayIcon"          "$\"$INSTDIR\${PRODUCT_NAME}.exe$\""
+          WriteRegStr   HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_UUID}" "DisplayIcon"          "$\"$INSTDIR\${PRODUCT_FILE}.exe$\""
           WriteRegStr   HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_UUID}" "Publisher"            "${PRODUCT_COMPANY}"
           WriteRegStr   HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_UUID}" "Comments"             "${PRODUCT_DESCRIPTION}"
           WriteRegStr   HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_UUID}" "DisplayVersion"       "${PRODUCT_VERSION}"
@@ -252,24 +264,24 @@ runs:
         WINEDEBUG: "-all"  # Disable WINE debug output
       shell: bash
       run: |
-        SFX_EXE="${{ inputs.output_folder }}/${{ inputs.product_name }}.exe"
+        SFX_EXE="${{ inputs.output_folder }}/${{ inputs.product_file }}.exe"
         # Create 7z archive of the game
         mkdir -p ./tools/build/sfx
-        7z a -mx=5 -m0=BCJ -m1=LZMA2 ./tools/build/sfx/${{ inputs.product_name }}.7z ./tools/build/win64/*
+        7z a -mx=5 -m0=BCJ -m1=LZMA2 ./tools/build/sfx/${{ inputs.product_file }}.7z ./tools/build/win64/*
 
         # Create SFX configuration
         cat > ./tools/config.txt << EOF
         ;!@Install@!UTF-8!
         Title="${{ inputs.product_name}}"
         Progress="no"
-        RunProgram="${{ inputs.product_name }}.exe"
+        RunProgram="${{ inputs.product_file }}.exe"
         ;!@InstallEnd@!
         EOF
 
         # Concatenate the SFX module, config and 7z archive
         cp -v ./tools/lzma-sdk/bin/7zSD.sfx "${SFX_EXE}"
         dd if=./tools/config.txt of="${SFX_EXE}" bs=1M oflag=append conv=notrunc
-        dd if=./tools/build/sfx/${{ inputs.product_name }}.7z of="${SFX_EXE}" bs=1M oflag=append conv=notrunc
+        dd if=./tools/build/sfx/${{ inputs.product_file }}.7z of="${SFX_EXE}" bs=1M oflag=append conv=notrunc
 
         env WINEARCH=win64 WINEPREFIX="$HOME/.wine-win64" wine ./tools/rcedit-win64.exe \
           "${SFX_EXE}" \
@@ -278,7 +290,7 @@ runs:
           --set-version-string FileDescription "${{ inputs.product_desc }}" \
           --set-version-string InternalName "${{ inputs.product_name }}" \
           --set-version-string LegalCopyright "${{ inputs.product_copyright }}" \
-          --set-version-string OriginalFilename "${{ inputs.product_name }}.exe" \
+          --set-version-string OriginalFilename "${{ inputs.product_file }}.exe" \
           --set-version-string PrivateBuild "${{ inputs.build_num }}" \
           --set-file-version "${{ inputs.build_num }}" \
           --set-product-version "${{ inputs.product_version }}" \

--- a/.github/actions/get-env/action.yml
+++ b/.github/actions/get-env/action.yml
@@ -21,9 +21,10 @@ runs:
             echo "ANDROID_RECORD=NoRecord" >> $GITHUB_ENV
           fi
 
-          # Convert PRODUCT_NAME to ITCH_GAME format only when processing PRODUCT_NAME
+          # Convert PRODUCT_NAME to formats suitable for use a filenames
           if [[ "${cleaned_line}" =~ ^PRODUCT_NAME= ]]; then
             product_value=${cleaned_line#PRODUCT_NAME=}
+            echo "PRODUCT_FILE=$(echo ${product_value} | tr ' ' '-')" >> $GITHUB_ENV
             echo "ITCH_GAME=$(echo ${product_value} | tr ' ' '-' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           fi
         done < ${{ inputs.env_file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url || '' }}
       itch_game: ${{ env.ITCH_GAME }}
       itch_user: ${{ env.ITCH_USER }}
+      product_file: ${{ env.PRODUCT_FILE }}
       product_id: ${{ env.PRODUCT_ID }}
       product_id_android: ${{ env.PRODUCT_ID_ANDROID || env.PRODUCT_ID }}
       product_id_ios: ${{ env.PRODUCT_ID_IOS || env.PRODUCT_ID }}
@@ -202,19 +203,18 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
       - name: Build LOVE package
         uses: ./.github/actions/build-love
         with:
           output_folder: ${{ env.OUTPUT_FOLDER }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_name: ${{ env.PRODUCT_NAME }}
       - name: Upload .love artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.love
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.love
+          name: ${{ env.PRODUCT_FILE }}.love
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.love
       - name: Upload .love release
         if: ${{ needs.configure.outputs.build_type == 'release' }}
         uses: actions/upload-release-asset@v1
@@ -222,8 +222,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.love
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.love
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.love
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.love
           asset_content_type: application/x-love-game
       - name: Upload .love to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' }}
@@ -233,7 +233,7 @@ jobs:
           channel: love
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.love
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.love
           version: ${{ env.PRODUCT_VERSION }}
 
   build-linux:
@@ -253,17 +253,11 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
-      - name: Build LOVE package
-        uses: ./.github/actions/build-love
-        with:
-          output_folder: ${{ env.OUTPUT_FOLDER }}
-          product_name: ${{ env.PRODUCT_NAME }}
       - name: Create AppImage
         uses: ./.github/actions/build-linux
         with:
           love_version: ${{ env.LOVE_VERSION }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_name: ${{ env.PRODUCT_NAME }}
           product_desc: ${{ env.PRODUCT_DESC }}
           output_folder: ${{ env.OUTPUT_FOLDER }}
@@ -271,20 +265,20 @@ jobs:
         if: ${{ needs.configure.outputs.build_type == 'dev' && env.TARGET_LINUX_APPIMAGE == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.AppImage
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.AppImage
+          name: ${{ env.PRODUCT_FILE }}.AppImage
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.AppImage
       - name: Upload AppImage artifact for SteamOS Devkit Client
         if: ${{ env.TARGET_LINUX_APPIMAGE == 'true' && env.ACT == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.AppImage
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.AppImage
+          name: ${{ env.PRODUCT_FILE }}.AppImage
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.AppImage
       - name: Upload Tarball artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' && env.TARGET_LINUX_TARBALL == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.tar.gz
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.tar.gz
+          name: ${{ env.PRODUCT_FILE }}.tar.gz
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.tar.gz
       - name: Upload AppImage release
         if: ${{ needs.configure.outputs.build_type == 'release' && env.TARGET_LINUX_APPIMAGE == 'true' }}
         uses: actions/upload-release-asset@v1
@@ -292,8 +286,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.AppImage
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.AppImage
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.AppImage
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.AppImage
           asset_content_type: application/x-executable
       - name: Upload Tarball release
         if: ${{ needs.configure.outputs.build_type == 'release' && env.TARGET_LINUX_TARBALL == 'true' }}
@@ -302,8 +296,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.tar.gz
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.tar.gz
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.tar.gz
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.tar.gz
           asset_content_type: application/gzip
       - name: Upload AppImage to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_linux_appimage == 'true' }}
@@ -313,11 +307,11 @@ jobs:
           channel: linux_appimage
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.AppImage
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.AppImage
           version: ${{ env.PRODUCT_VERSION }}
 
   build-windows:
-    if: ${{ needs.configure.outputs.target_windows_zip == 'true' || needs.configure.outputs.target_windows_setup == 'true' || needs.configure.outputs.target_windows_sfx == 'true' }}
+    if: ${{ needs.configure.outputs.target_windows_zip == 'true' || needs.configure.outputs.target_windows_install == 'true' || needs.configure.outputs.target_windows_sfx == 'true' }}
     runs-on: ubuntu-22.04
     needs: [configure]
     continue-on-error: true
@@ -333,13 +327,6 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
-      - name: Build LOVE package
-        uses: ./.github/actions/build-love
-        with:
-          output_folder: ${{ env.OUTPUT_FOLDER }}
-          product_name: ${{ env.PRODUCT_NAME }}
       - name: Build Windows
         uses: ./.github/actions/build-windows
         with:
@@ -347,6 +334,7 @@ jobs:
           build_type: ${{ needs.configure.outputs.build_type }}
           love_version: ${{ env.LOVE_VERSION }}
           product_desc: ${{ env.PRODUCT_DESC }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_name: ${{ env.PRODUCT_NAME }}
           product_company: ${{ env.PRODUCT_COMPANY }}
           product_copyright: ${{ env.PRODUCT_COPYRIGHT }}
@@ -364,20 +352,20 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: false
           compression-level: 9
-          name: ${{ env.PRODUCT_NAME }}
+          name: ${{ env.PRODUCT_FILE }}
           path: ./tools/build/win64/*
       - name: Upload Windows SFX artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' && needs.configure.outputs.target_windows_sfx == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.exe
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.exe
+          name: ${{ env.PRODUCT_FILE }}.exe
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.exe
       - name: Upload Windows Install artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' && needs.configure.outputs.target_windows_install == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}-installer.exe
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-installer.exe
+          name: ${{ env.PRODUCT_FILE }}-installer.exe
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}-installer.exe
       - name: Upload Windows .zip release
         if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_windows_zip == 'true' }}
         uses: actions/upload-release-asset@v1
@@ -385,8 +373,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.zip
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.zip
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.zip
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.zip
           asset_content_type: application/zip
       - name: Upload Windows Install release
         if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_windows_install == 'true' }}
@@ -395,8 +383,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-installer.exe
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}-installer.exe
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}-installer.exe
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}-installer.exe
           asset_content_type: application/x-msdownload
       - name: Upload Windows SFX release
         if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_windows_sfx == 'true' }}
@@ -405,8 +393,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.exe
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.exe
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.exe
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.exe
           asset_content_type: application/x-msdownload
       - name: Upload Windows Install to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_windows_install == 'true' }}
@@ -416,7 +404,7 @@ jobs:
           channel: windows
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-installer.exe
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}-installer.exe
           version: ${{ env.PRODUCT_VERSION }}
       - name: Upload Windows SFX to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' && needs.configure.outputs.target_windows_sfx == 'true' }}
@@ -426,7 +414,7 @@ jobs:
           channel: windows
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.exe
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.exe
           version: ${{ env.PRODUCT_VERSION }}
 
   build-html:
@@ -446,35 +434,18 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
-      - name: Build LOVE package
-        uses: ./.github/actions/build-love
+      - name: Build HTML package
+        uses: ./.github/actions/build-html
         with:
           output_folder: ${{ env.OUTPUT_FOLDER }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_name: ${{ env.PRODUCT_NAME }}
-      - name: Build love.js
-        run: |
-          curl -fsSL --retry 5 --retry-delay 15 --connect-timeout 30 --max-time 300 https://github.com/2dengine/love.js/archive/refs/heads/main.zip -o ./tools/love.js.zip || exit 1
-          unzip -q ./tools/love.js.zip -d ./tools/
-          sed -i "s/<title>löve.js<\/title>/<title>${PRODUCT_NAME}<\/title>/" ./tools/love.js-main/index.html
-          sed -i '/<base href="\/play\/">$/d' ./tools/love.js-main/index.html
-          sed -i "s/player.js/player.js?g=game.love/" ./tools/love.js-main/index.html
-          convert ./resources/icon.png -define icon:auto-resize="256,128,96,64,48,32,24,16" ./tools/love.js-main/favicon.ico
-          mkdir -p ${OUTPUT_FOLDER}/${PRODUCT_NAME}-html
-          rsync -a --exclude='.htaccess' --exclude='*.git*' --exclude='*.md' --exclude='*.txt' \
-            ./tools/love.js-main/ \
-            ${OUTPUT_FOLDER}/${PRODUCT_NAME}-html/
-          cp -v ${OUTPUT_FOLDER}/${PRODUCT_NAME}.love ${OUTPUT_FOLDER}/${PRODUCT_NAME}-html/game.love
-          7z a -tzip \
-            "${OUTPUT_FOLDER}/${PRODUCT_NAME}-html.zip" \
-            "${OUTPUT_FOLDER}/${PRODUCT_NAME}-html"/*
       - name: Upload HTML artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}-html
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-html
+          name: ${{ env.PRODUCT_FILE }}-html
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}-html
       - name: Upload HTML release
         if: ${{ needs.configure.outputs.build_type == 'release' }}
         uses: actions/upload-release-asset@v1
@@ -482,8 +453,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-html.zip
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}-html.zip
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}-html.zip
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}-html.zip
           asset_content_type: application/zip
       - name: Upload HTML release to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' }}
@@ -493,7 +464,7 @@ jobs:
           channel: html
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}-html
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}-html
           version: ${{ env.PRODUCT_VERSION }}
 
   build-android:
@@ -515,8 +486,6 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
       - name: Build Android
         uses: ./.github/actions/build-android
         with:
@@ -528,6 +497,7 @@ jobs:
           android_version_code: ${{ needs.configure.outputs.android_version_code }}
           build_num: ${{ needs.configure.outputs.build_num }}
           build_type: ${{ needs.configure.outputs.build_type }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_name: ${{ env.PRODUCT_NAME }}
           product_id: ${{ needs.configure.outputs.product_id_android }}
           output_folder: ${{ env.OUTPUT_FOLDER }}
@@ -574,13 +544,13 @@ jobs:
         if: ${{ needs.configure.outputs.build_type == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}-debug-signed.apk
+          name: ${{ env.PRODUCT_FILE }}-debug-signed.apk
           path: ${{ steps.sign-apk-debug.outputs.signedReleaseFile }}
       - name: Upload Android release .apk artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}-release-signed.apk
+          name: ${{ env.PRODUCT_FILE }}-release-signed.apk
           path: ${{ steps.sign-apk-release.outputs.signedReleaseFile }}
       - name: Upload Android release .apk
         if: ${{ needs.configure.outputs.build_type == 'release' }}
@@ -589,7 +559,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}-release.apk
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}-release.apk
           asset_path: ${{ steps.sign-apk-release.outputs.signedReleaseFile }}
           asset_content_type: application/vnd.android.package-archive
       - name: Upload Android release .aab
@@ -599,13 +569,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}-release.aab
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}-release.aab
           asset_path: ${{ steps.sign-aab-release.outputs.signedReleaseFile }}
           asset_content_type: application/vnd.android.package-archive
       - name: Create unversioned Android .apk for itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' }}
         run: |
-          cp -v "${{ steps.sign-apk-release.outputs.signedReleaseFile }}" "${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.apk"
+          cp -v "${{ steps.sign-apk-release.outputs.signedReleaseFile }}" "${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.apk"
       - name: Upload Android .apk to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' }}
         uses: ./.github/actions/publish-itch
@@ -614,7 +584,7 @@ jobs:
           channel: android
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.apk
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.apk
           version: ${{ env.PRODUCT_VERSION }}
 
   build-macos:
@@ -636,19 +606,13 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
-      - name: Build LOVE package
-        uses: ./.github/actions/build-love
-        with:
-          output_folder: ${{ env.OUTPUT_FOLDER }}
-          product_name: ${{ env.PRODUCT_NAME }}
       - name: Build macOS
         uses: ./.github/actions/build-macos
         with:
           apple_version_code: ${{ needs.configure.outputs.apple_version_code }}
           love_version: ${{ env.LOVE_VERSION }}
           product_copyright: ${{ env.PRODUCT_COPYRIGHT }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_id: ${{ needs.configure.outputs.product_id_macos }}
           product_name: ${{ env.PRODUCT_NAME }}
           product_version: ${{ env.PRODUCT_VERSION }}
@@ -657,14 +621,14 @@ jobs:
         if: ${{ needs.configure.outputs.build_type == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.app
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}.app.zip
+          name: ${{ env.PRODUCT_FILE }}.app
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.app.zip
       - name: Upload macOS .dmg artifact
         if: ${{ needs.configure.outputs.build_type == 'dev' && runner.os == 'macOS' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.dmg
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.dmg
+          name: ${{ env.PRODUCT_FILE }}.dmg
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.dmg
       - name: Upload macOS .app release
         if: ${{ needs.configure.outputs.build_type == 'release' }}
         uses: actions/upload-release-asset@v1
@@ -672,8 +636,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.app.zip
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}.app.zip
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.app.zip
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.app.zip
           asset_content_type: application/zip
       - name: Upload macOS .dmg release
         if: ${{ needs.configure.outputs.build_type == 'release' }}
@@ -682,8 +646,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.dmg
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}.dmg
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.dmg
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.dmg
           asset_content_type: application/x-apple-diskimage
       - name: Upload macOS .dmg to itch.io
         if: ${{ needs.configure.outputs.build_type == 'release' }}
@@ -693,7 +657,7 @@ jobs:
           channel: osx
           itch_game: ${{ needs.configure.outputs.itch_game }}
           itch_user: ${{ needs.configure.outputs.itch_user }}
-          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME  }}.dmg
+          package: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.dmg
           version: ${{ env.PRODUCT_VERSION }}
 
   build-ios:
@@ -713,13 +677,6 @@ jobs:
         uses: ./.github/actions/get-env
         with:
           env_file: game/product.env
-      - name: Install tools
-        uses: ./.github/actions/install-tools
-      - name: Build LOVE package
-        uses: ./.github/actions/build-love
-        with:
-          output_folder: ${{ env.OUTPUT_FOLDER }}
-          product_name: ${{ env.PRODUCT_NAME }}
       - name: Build iOS
         uses: ./.github/actions/build-ios
         with:
@@ -727,6 +684,7 @@ jobs:
           love_version: ${{ env.LOVE_VERSION }}
           product_company: ${{ env.PRODUCT_COMPANY }}
           product_copyright: ${{ env.PRODUCT_COPYRIGHT }}
+          product_file: ${{ env.PRODUCT_FILE }}
           product_id: ${{ needs.configure.outputs.product_id_ios }}
           product_name: ${{ env.PRODUCT_NAME }}
           product_version: ${{ env.PRODUCT_VERSION }}
@@ -735,8 +693,8 @@ jobs:
         if: ${{ needs.configure.outputs.build_type == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT_NAME }}.ipa
-          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.ipa
+          name: ${{ env.PRODUCT_FILE }}.ipa
+          path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.ipa
       - name: Upload iOS release
         if: ${{ needs.configure.outputs.build_type == 'release' }}
         uses: actions/upload-release-asset@v1
@@ -744,8 +702,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.configure.outputs.upload_url }}
-          asset_name: ${{ env.PRODUCT_NAME }}-${{ env.PRODUCT_VERSION }}.ipa
-          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_NAME }}.ipa
+          asset_name: ${{ env.PRODUCT_FILE }}-${{ env.PRODUCT_VERSION }}.ipa
+          asset_path: ${{ env.OUTPUT_FOLDER }}/${{ env.PRODUCT_FILE }}.ipa
           asset_content_type: application/octet-stream
   summary:
     name: Build parameters

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           # Pinned packages available in the environment
           packages = with pkgs; [
             act
+            netcat-gnu
             luaformatter
             luajit
             lua-language-server

--- a/tools/build-love.sh
+++ b/tools/build-love.sh
@@ -4,18 +4,17 @@
 if command -v act &>/dev/null; then
   act -j build-love
 elif command -v 7z &>/dev/null; then
-  # Get the PRODUCT_NAME from product.env
-  PRODUCT_NAME=$(grep -E "^PRODUCT_NAME=" ./game/product.env | cut -d'"' -f2)
-
+  source ./game/product.env
   # Check if PRODUCT_NAME was found
   if [ -z "${PRODUCT_NAME}" ]; then
     echo "Error: Could not find PRODUCT_NAME in game/product.env"
     exit 1
   fi
+  PRODUCT_FILE="$(echo "${PRODUCT_NAME}" | tr ' ' '-')"
 
   mkdir -p "./builds/1"
   7z a -tzip -mx=6 -mpass=15 -mtc=off \
-    "./builds/1/${PRODUCT_NAME}.love" \
+    "./builds/1/${PRODUCT_FILE}.love" \
     ./game/* \
     -xr!.gitkeep
 else


### PR DESCRIPTION
PRODUCT_FILE is derived from PRODUCT_NAME with spaces converted to hyphens. PRODUCT_FILE is then passed as an input to the build actions so builds work reliably.