### PR TITLE
fix html build

### DIFF
--- a/.github/actions/build-html/action.yml
+++ b/.github/actions/build-html/action.yml
@@ -28,7 +28,7 @@ runs:
         unzip -q ./tools/love.js.zip -d ./tools/
         sed -i "s/<title>löve.js<\/title>/<title>${{ inputs.product_name }}<\/title>/" ./tools/love.js-main/index.html
         sed -i '/<base href="\/play\/">$/d' ./tools/love.js-main/index.html
-        sed -i "s/player.js/player.js?g=game.love/" ./tools/love.js-main/index.html
+        sed -i "s/player.min.js/player.min.js?g=game.love/" ./tools/love.js-main/index.html
         convert ./resources/icon.png -define icon:auto-resize="256,128,96,64,48,32,24,16" ./tools/love.js-main/favicon.ico
         mkdir -p "${{ inputs.output_folder }}/${{ inputs.product_file }}-html"
         rsync -a --exclude='.htaccess' --exclude='*.git*' --exclude='*.md' --exclude='*.txt' \


### PR DESCRIPTION
# Fix Web Build

The [commit](https://github.com/2dengine/love.js/commit/0c2116b23b39ff34a2094a971df296f8a75d9924#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R13) broke the HTML build action. The `index.html` now uses the minified player.js version, but the build action was looking for the `player.js` instead of `player.min.js`.
