### PR TITLE
Build .app for macOS in Linux environment

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -162,7 +162,7 @@ runs:
         if command -v ditto >/dev/null 2>&1; then
           ditto -c -k --keepParent ./tools/${{ inputs.product_file }}.app ${{ inputs.output_folder }}/${{ inputs.product_file }}.app.zip
         else
-          zip -ry --symlinks ${{ inputs.output_folder }}/${{ inputs.product_file }}.app.zip ./tools/${{ inputs.product_file }}.app
+          ( cd tools && zip -ry --symlinks ../${{ inputs.output_folder }}/${{ inputs.product_file }}.app.zip ./${{ inputs.product_file }}.app )
         fi
         tree ${{ inputs.output_folder }}
     - name: Create macOS .dmg of .app

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -22,6 +22,21 @@ runs:
             libfuse2 \
             tree \
             xmlstarlet
+          if [ "$GITHUB_JOB" == "build-macos" ] && ! command -v plutil; then
+            sudo apt-get -y install \
+              build-essential \
+              cmake \
+              git \
+              libpng-dev \
+              libpng16-16 \
+              libxml2-dev \
+              pkg-config \
+              ninja-build
+            git clone --depth 1 https://github.com/CallMeEchoCodes/plutil
+            cd plutil
+            make
+            sudo make install
+          fi
         elif [ "${RUNNER_OS}" == "macOS" ]; then
           brew install \
             create-dmg \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -732,7 +732,7 @@ jobs:
           echo "- Android:          ${{ env.TARGET_ANDROID == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
           echo "- AppImage:         ${{ env.TARGET_LINUX_APPIMAGE == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
           echo "- iOS:              ${{ env.TARGET_IOS == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- HTML:              ${{ env.TARGET_HTML == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- HTML:             ${{ env.TARGET_HTML == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
           echo "- macOS:            ${{ env.TARGET_MACOS == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Tarball:          ${{ env.TARGET_LINUX_TARBALL == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Windows Installer ${{ env.TARGET_WINDOWS_INSTALL == 'true' && '✅' || '❌' }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Description

Currently, it's only possible to build for macOS using `act` with `-P macos-latest=-self-hosted`. This limitation comes from `plutil` not being available on Linux.

I have found [a cross-platform, drop-in replacement for plutil](https://github.com/withgraphite/plutil). The downside: no binaries available, needs to be compiled from source.

So I just added these compilation steps to the script that sets up the environment. They are running conditionally, only when building on Linux for macOS and `plutil` is not found in PATH.

Now it can be tested by running `act -P macos-latest=catthehacker/ubuntu:act-22.04`. Alternatively, you can specify your own Docker image with `plutil` binary included, this would allow to skip the compilation and speed up the whole process.

The resulting package needs to be compared against similar created with `-self-hosted` option, and if there are no significant differences, this can be merged.

<!-- Close any related issues. Delete if not relevant -->

## Type of change

<!-- Delete any that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

<!-- Delete any that are not relevant -->

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
