### PR TITLE
ci(Windows Build): Updates LZMA SDK download URL for Windows build

### DIFF
--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -87,7 +87,7 @@ runs:
           rm ./tools/love-${ARCH}/changes.txt
           rm ./tools/love-${ARCH}/readme.txt
         done
-        curl -fsSL --retry 5 --retry-delay 15 --connect-timeout 30 --max-time 300 https://www.7-zip.org/a/lzma2409.7z -o ./tools/lzma-sdk.7z || exit 1
+        curl -fsSL --retry 5 --retry-delay 15 --connect-timeout 30 --max-time 300 https://www.7-zip.org/a/lzma2600.7z -o ./tools/lzma-sdk.7z || exit 1
         mkdir -p ./tools/lzma-sdk
         7z x -o./tools/lzma-sdk/ ./tools/lzma-sdk.7z
     - name: Create .ico icon


### PR DESCRIPTION
The Windows build job was failing due to a 404 error when attempting to download the LZMA SDK from the old URL (`https://www.7-zip.org/a/lzma2409.7z`).

Updates the download URL to the latest available version (`https://www.7-zip.org/a/lzma2600.7z`), which resolves the build failure.

# Description

Please include a summary of the changes and any relevant motivation and context.



- Closes #95 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- Delete any that are not relevant -->

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

